### PR TITLE
Fix for Mono IPv6 properties breakage.

### DIFF
--- a/Tmds/MDns/NetworkInterfaceHandler.cs
+++ b/Tmds/MDns/NetworkInterfaceHandler.cs
@@ -228,7 +228,17 @@ namespace Tmds.MDns
                                 {
                                     continue;
                                 }
-                                address.ScopeId = NetworkInterface.Information.GetIPProperties().GetIPv6Properties().Index;
+
+                                // Mono does not support IPv6 properties and always throws NotImplementedException.
+                                // Lets handle the case as with Supports.
+                                try
+                                {
+                                    address.ScopeId = NetworkInterface.Information.GetIPProperties().GetIPv6Properties().Index;
+                                }
+                                catch (NotImplementedException)
+                                {
+                                    continue;
+                                }
                             }
                             OnARecord(recordHeader.Name, address, recordHeader.Ttl);
                         }


### PR DESCRIPTION
While the library is not advertised to work for Linux+Mono, it, for most part, actually does.

Apparently, I found out that on "Changed" event, it would bail out with `NotImplementedException` due to `GetIPv6Properties()` being ... well, not implemented in Mono for `UnixIPInterfaceProperties`, as can be seen here: https://github.com/mono/mono/blob/88d2b9da2a87b4e5c82abaea4e5110188d49601d/mcs/class/System/System.Net.NetworkInformation/IPInterfaceProperties.cs#L72

While this is a issue on Mono's half, providing a temporary fix in the library itself seems to be a great idea.

The fix is fairly simple, I'm catching the `NotImplementedException` and handling it the same way as with `NetworkInterface.Supports` - just `continue` over to next item.

I agree that this is a dirty fix and does not address the issue properly, but it does the job.