### PR TITLE
ServiceBrowser: don't browse interfaces that don't have multicast enabled

### DIFF
--- a/src/Tmds.MDns/ServiceBrowser.cs
+++ b/src/Tmds.MDns/ServiceBrowser.cs
@@ -245,6 +245,10 @@ namespace Tmds.MDns
                     {
                         continue;
                     }
+                    if (!networkInterface.SupportsMulticast)
+                    {
+                        continue;
+                    }
 
                     int index = networkInterface.GetIPProperties().GetIPv4Properties().Index;
                     NetworkInterfaceHandler interfaceHandler;


### PR DESCRIPTION
Setting multicast related socket options on interfaces that don't have
multicast enabled causes exceptions: https://github.com/tmds/Tmds.MDns/issues/8.

MDns needs multicast to work so we skip interfaces which don't have multicast
enabled.
