### PR TITLE
Closes #42 Fixes application crash due to uncaught exception from GetLinuxNetworkInterfaces

### DIFF
--- a/src/Tmds.MDns/ServiceBrowser.cs
+++ b/src/Tmds.MDns/ServiceBrowser.cs
@@ -226,7 +226,7 @@ namespace Tmds.MDns
 
             _networkAvailabilityChangedEventHandler = (s, e) =>
             {
-                 CheckNetworkInterfaceStatuses(interfaceHandlers);
+                CheckNetworkInterfaceStatuses(interfaceHandlers);
             };
             NetworkChange.NetworkAvailabilityChanged += _networkAvailabilityChangedEventHandler;
 
@@ -243,7 +243,18 @@ namespace Tmds.MDns
                 }
 
                 HashSet<NetworkInterfaceHandler> handlers = new HashSet<NetworkInterfaceHandler>(_interfaceHandlers.Values);
-                var networkInterfaces = NetworkInterface.GetAllNetworkInterfaces();
+                NetworkInterface[] networkInterfaces = Array.Empty<NetworkInterface>();
+                try
+                {
+                    networkInterfaces = NetworkInterface.GetAllNetworkInterfaces();
+                }
+                catch (System.ArgumentException)
+                {
+                    // Workaround for bug reported https://github.com/tmds/Tmds.MDns/issues/42
+                    // and https://github.com/dotnet/runtime/issues/49515
+                    return;
+                }
+
                 foreach (NetworkInterface networkInterface in networkInterfaces)
                 {
                     if (networkInterface.NetworkInterfaceType == NetworkInterfaceType.Tunnel)

--- a/src/Tmds.MDns/ServiceBrowser.cs
+++ b/src/Tmds.MDns/ServiceBrowser.cs
@@ -248,10 +248,10 @@ namespace Tmds.MDns
                 {
                     networkInterfaces = NetworkInterface.GetAllNetworkInterfaces();
                 }
-                catch (System.ArgumentException)
+                catch
                 {
-                    // Workaround for bug reported https://github.com/tmds/Tmds.MDns/issues/42
-                    // and https://github.com/dotnet/runtime/issues/49515
+                    // Before .NET 11, GetAllNetworkInterfaces can throw when an interface disappears during enumeration (https://github.com/dotnet/runtime/issues/49515).                                                                                                                         
+                    // The next network change event will retry.
                     return;
                 }
 


### PR DESCRIPTION
Added try catch block around NetworkInterface.GetAllNetworkInterfaces() to prevent the application from crashing due to unhandled exceptions