### PR TITLE
Query for TXT records, so services resolve against responders that answer strictly

### DIFF
--- a/src/Tmds.MDns/NetworkInterfaceHandler.cs
+++ b/src/Tmds.MDns/NetworkInterfaceHandler.cs
@@ -873,6 +873,11 @@ namespace Tmds.MDns
                         writer.WriteQuestion(serviceKV.Value.Name, RecordType.SRV);
                         sendQuery = true;
                     }
+                    if (serviceKV.Value.Txt == null)
+                    {
+                        writer.WriteQuestion(serviceKV.Value.Name, RecordType.TXT);
+                        sendQuery = true;
+                    }
                 }
 
                 foreach (var hostKV in _hostInfos)


### PR DESCRIPTION
[ServiceInfo.IsComplete](https://github.com/tmds/Tmds.MDns/blob/41b0c01bcf0fd6a29cd4b6eb981fbe55373e4a31/src/Tmds.MDns/ServiceInfo.cs#L39-L45) required a TXT to be not null, **but there currently is no explicit query for TXT fields.**  So if a mDNS implementation does not send along TXT fields with other queries a service info is never flagged as complete and will never land in the Services Collection.

Systemd resolved for example does not send along TXT fields with other queries, so services announced by resolved are currently never discovered - while it works fine for Avahi or Apples mDNSResponder.

